### PR TITLE
Replace expo by react-native-svg

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,7 @@ import PropTypes from "prop-types";
 import xmldom from "xmldom";
 import resolveAssetSource from "react-native/Libraries/Image/resolveAssetSource";
 
-import { Svg } from "expo";
-const {
+import Svg, {
   Circle,
   Ellipse,
   G,
@@ -20,7 +19,7 @@ const {
   TSpan,
   Defs,
   Stop
-} = Svg;
+} from "react-native-svg";
 
 import * as utils from "./utils";
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "xmldom": "^0.1.27"
   },
   "peerDependencies": {
-    "expo": "^31.0.5"
+    "react-native-svg": "~9.5.1"
   }
 }


### PR DESCRIPTION
Expo does not export the `Svg` symbol anymore.

We should use the `react-native-svg` package from now on (see the [Expo docs](https://docs.expo.io/versions/latest/sdk/svg)).