### PR TITLE
Stroke color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ yarn add expo-svg-uri
 | `source`     | `ImageSource` |                                              | Same kind of `source` prop that `<Image />` component has |
 | `svgXmlData` | `String`      |                                              | You can pass the SVG as String directly                   |
 | `fill`       | `Color`       |                                              | Overrides all fill attributes of the svg file             |
+| `stroke`     | `Color`       |                                              | Overrides all stroke attributes of the svg file           |
 | `fillAll`    | `Boolean`     | Adds the fill color to the entire svg object |
 
 ## Usage

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,11 @@ interface SvgUriProps {
    * Fill color for the svg object
    */
   fill?: string;
+  
+  /**
+   * Stroke color for the svg object
+   */
+  stroke?: string;
 
   /**
    * Invoked when load completes successfully.

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ class SvgUri extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { fill: props.fill, svgXmlData: props.svgXmlData };
+    this.state = { fill: props.fill, svgXmlData: props.svgXmlData, stroke: props.stroke };
 
     this.createSVGElement = this.createSVGElement.bind(this);
     this.obtainComponentAtts = this.obtainComponentAtts.bind(this);
@@ -322,10 +322,28 @@ class SvgUri extends Component {
       .map(utils.removePixelsFromNodeValue)
       .filter(utils.getEnabledAttributes(enabledAttributes.concat(COMMON_ATTS)))
       .reduce((acc, { nodeName, nodeValue }) => {
-        acc[nodeName] =
-          this.state.fill && nodeName === "fill" && nodeValue !== "none"
-            ? this.state.fill
-            : nodeValue;
+        if(nodeValue === "none") {
+          acc[nodeName] = nodeValue		
+        } else {
+          switch(nodeName) {
+            case "fill":
+              acc[nodeName] =
+                this.state.fill
+                  ? this.state.fill
+                  : nodeValue;
+              break
+            case "stroke":
+              acc[nodeName] =
+                this.state.stroke
+                  ? this.state.stroke
+                  : nodeValue;
+              break
+            default:
+              acc[nodeName] = nodeValue
+              break
+		  }
+        }
+
         return acc;
       }, {});
     Object.assign(componentAtts, styleAtts);
@@ -393,6 +411,7 @@ SvgUri.propTypes = {
   svgXmlData: PropTypes.string,
   source: PropTypes.any,
   fill: PropTypes.string,
+  stroke: PropTypes.string,
   onLoad: PropTypes.func,
   fillAll: PropTypes.bool,
 };


### PR DESCRIPTION
This adds the ability to override stroke colors of an SVG through the `stroke` prop.
`<SvgUri source={require("./icon.svg")} width={24} height={24} stroke="#FFFFFF" />`