### PR TITLE
Fix: Reactivity for stroke prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,6 +140,10 @@ class SvgUri extends Component {
     if (nextProps.fill !== this.props.fill) {
       this.setState({ fill: nextProps.fill });
     }
+
+    if (nextProps.stroke !== this.props.stroke) {
+      this.setState({ stroke: nextProps.stroke });
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
I discovered that the new `stroke` prop was not reactive. 
This pull request adds reactivity to the `stroke` prop.